### PR TITLE
tideways-daemon in a docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM cheggwpt/alpine:edge
+
+ENV tideways_version 1.5.3
+
+RUN apk add --no-cache --update wget && \
+  	cd /tmp && \
+    wget https://s3-eu-west-1.amazonaws.com/tideways/daemon/${tideways_version}/tideways-daemon-v${tideways_version}-alpine.tar.gz && \
+	tar -zxf tideways-daemon-v${tideways_version}-alpine.tar.gz && \
+	mv build/dist/tideways-daemon /usr/bin && \
+	ls -l /usr/bin/tideways-daemon && \
+	mkdir -p /var/run/tideways && \
+    rm -rf build/ tideways-daemon-v${tideways_version}-alpine.tar.gz && \
+	apk del wget && \
+	rm -rf /var/cache/apk/*
+
+EXPOSE 8135/udp
+EXPOSE 9135
+
+ENTRYPOINT ["/usr/bin/tideways-daemon"]


### PR DESCRIPTION
TODO:

- [ ] add automatic build to Docker hub!

```
Tills-MBP:tideways-daemon till$ docker run -it 4810d7edeec5
2017/01/16 16:30:18 Starting up daemon (version @@@DEV@@@)
2017/01/16 16:30:18 Sending to https://ingest.tideways.io
2017/01/16 16:30:18 Collecting for 17596b572f8d
2017/01/16 16:30:18 Supported server stats: CPU [X]  Memory [X]  Load [X]  Disk [X]  Network [X]
2017/01/16 16:30:18 Listening for Unix Socket connections at /var/run/tideways/tidewaysd.sock.
2017/01/16 16:30:18 Listening for UDP connections 127.0.0.1:8135
```

Related: easybib/issues#5925