### PR TITLE
Enhancement: allow configuration via standard env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM cheggwpt/alpine:edge
 
+ENV TIDEWAYS_PORT_UDP 8135
+ENV TIDEWAYS_PORT_TCP 9135
+ENV TIDEWAYS_ENV "development"
 ENV tideways_version 1.5.3
+ENV TIDEWAYS_DAEMON_EXTRA "--env=${TIDEWAYS_ENV} --address=0.0.0.0:${TIDEWAYS_PORT_TCP} --udp=0.0.0.0:${TIDEWAYS_PORT_UDP}"
 
 RUN apk add --no-cache --update wget && \
   	cd /tmp && \
@@ -13,7 +17,9 @@ RUN apk add --no-cache --update wget && \
 	apk del wget && \
 	rm -rf /var/cache/apk/*
 
-EXPOSE 8135/udp
-EXPOSE 9135
+COPY entrypoint.sh /
 
-ENTRYPOINT ["/usr/bin/tideways-daemon"]
+EXPOSE $TIDEWAYS_PORT_UDP/udp
+EXPOSE $TIDEWAYS_PORT_TCP
+
+ENTRYPOINT ["/entrypoint.sh", "tideways-daemon"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# entrypoint for container
+# ----------------------------------------------------------------------------
+set -e
+
+HOST_IP=`/bin/grep $HOSTNAME /etc/hosts | /usr/bin/cut -f1`
+export HOST_IP=${HOST_IP}
+
+echo
+echo "container started with ip: ${HOST_IP}..."
+echo
+
+if [ "$1" == "tideways-daemon" ]; then
+	echo "starting tideways-daemon, with: ${TIDEWAYS_DAEMON_EXTRA}"
+	/usr/bin/tideways-daemon $TIDEWAYS_DAEMON_EXTRA
+elif [ "$1" == "bash" ] || [ "$1" == "shell" ]; then
+	echo "starting /bin/bash with /etc/profile..."
+	/bin/bash --rcfile /etc/profile
+else
+	echo "Running something else ($@)"
+	exec "$@"
+fi


### PR DESCRIPTION
Related: easybib/issues#5925

---

```
$ docker exec -it d0c62fdae381 bash
bash-4.3# ps aux
PID   USER     TIME   COMMAND
    1 root       0:00 {entrypoint.sh} /bin/sh /entrypoint.sh tideways-daemon
    8 root       0:00 /usr/bin/tideways-daemon --env=development --address=0.0.0.0:9135 --udp=0.0.0.0:8135
   16 root       0:00 bash
   20 root       0:00 ps aux
bash-4.3# netstat -l
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       
tcp        0      0 :::9135                 :::*                    LISTEN      
udp        0      0 :::8135                 :::*                                
Active UNIX domain sockets (only servers)
Proto RefCnt Flags       Type       State         I-Node Path
bash-4.3#